### PR TITLE
Consider adding an ignore string to skip some repos.

### DIFF
--- a/uncommitted/command.py
+++ b/uncommitted/command.py
@@ -103,6 +103,14 @@ def scan(repos, options):
     """Given a repository list [(path, vcsname), ...], scan each of them."""
     ignore_set = set()
     for directory, dotdir in repos:
+        """ Skip this repo if -I is used and the directoy contains the ignore string """
+        if options.ignore_dir and options.ignore_dir in directory:
+            if options.verbose:
+                """ Output ignored repos if verbose """
+                print ("Ignoring repo at: " + directory)
+                print
+            continue
+
         vcsname, get_status = SYSTEMS[dotdir]
         lines = get_status(directory, ignore_set, options)
         if lines is None:  # signal that we should ignore this one
@@ -125,6 +133,8 @@ def main():
         help='follow symbolic links when walking file tree')
     parser.add_option('-u', '--untracked', action='store_true',
         help='print untracked files (git only)')
+    parser.add_option('-I', dest='ignore_dir', action='store', type="string",
+        help='ignore any directory paths that contain the specified string')
     (options, args) = parser.parse_args()
 
     if not args:

--- a/uncommitted/test_integration.py
+++ b/uncommitted/test_integration.py
@@ -69,7 +69,7 @@ def checkouts(git_identity, tempdir, cc):
     os.mkdir(checkouts_dir)
 
     for system in 'git', 'hg', 'svn':
-        for state in 'clean', 'dirty':
+        for state in 'clean', 'dirty', 'ignoredirectory':
             d = os.path.join(checkouts_dir, system + '-' + state)
 
             # Create the repo:
@@ -97,7 +97,7 @@ def checkouts(git_identity, tempdir, cc):
                 cc([system, 'commit', '-m', 'Add more maxim'], cwd=d)
 
             # Make the master branch dirty:
-            if state == 'dirty':
+            if state == 'dirty' or state == 'ignoredirectory':
                 with open(file_to_edit, 'a') as f:
                     f.write(even_more_maxim)
 
@@ -164,6 +164,34 @@ def run(*args):
 def test_uncommitted(checkouts):
     """Do we detect repositories having uncommitted changes?"""
     actual_output = run(checkouts)
+
+    # All dirty checkouts and only them:
+    expected_output = dedent("""\
+        {path}/git-dirty - Git
+         M {filename}
+
+        {path}/git-ignoredirectory - Git
+         M {filename}
+
+        {path}/hg-dirty - Mercurial
+         M {filename}
+
+        {path}/hg-ignoredirectory - Mercurial
+         M {filename}
+
+        {path}/svn-dirty - Subversion
+         M       {filename}
+
+        {path}/svn-ignoredirectory - Subversion
+         M       {filename}
+
+        """).format(path=checkouts, filename=filename)
+
+    assert actual_output == expected_output
+
+def test_uncommittedIgnore(checkouts):
+    """Do we detect repositories having uncommitted changes that are not ignored?"""
+    actual_output = run("-Iignoredirectory", checkouts)
 
     # All dirty checkouts and only them:
     expected_output = dedent("""\

--- a/uncommitted/test_integration.py
+++ b/uncommitted/test_integration.py
@@ -15,7 +15,7 @@ if sys.version_info.major > 2:
 else:
     from StringIO import StringIO
 
-@pytest.fixture(scope='module')
+@pytest.yield_fixture(scope='module')
 def tempdir():
     """Temporary directory in which all tests will run."""
     tempdir = tempfile.mkdtemp(prefix='uncommitted-test')


### PR DESCRIPTION
I have a case where the build environment modifies GIT repos in a build output directory, and this directory is a sibling to a number of GIT repos. When I run uncommited, it finds all of these transient changes within the build directory. I would like to add a string to ignore paths that contain a specific string.

  -I  "skip/path/withthis/string"