### PR TITLE
Ignore SVN states

### DIFF
--- a/uncommitted/command.py
+++ b/uncommitted/command.py
@@ -95,6 +95,9 @@ def status_subversion(path, ignore_set, options):
         if line.startswith('Performing') or line[0] in 'X?':
             continue
         status = line[:8]
+        ignored_states = options.ignore_svn_states
+        if ignored_states and status.strip() in ignored_states:
+            continue
         filename = line[8:].split(None, 3)[-1]
         ignore_set.add(os.path.join(path, filename))
         if status.strip():
@@ -148,6 +151,10 @@ def main():
     parser.add_option('-I', dest='ignore_patterns', action='append',
         default=[],
         help='ignore any directory paths that contain the specified string')
+    parser.add_option(
+        '--ignore-svn-states',
+        help='ignore SVN states given as a string of status codes (SVN only)')
+
     (options, args) = parser.parse_args()
 
     if not args:

--- a/uncommitted/test_integration.py
+++ b/uncommitted/test_integration.py
@@ -413,3 +413,52 @@ def test_follow_symlinks(checkouts):
         """).format(path=symlink, filename=filename)
 
     assert actual_output == expected_output
+
+
+@pytest.fixture(scope='module')
+def svn_locked(tempdir, cc):
+    """SVN repo containing a locked file.
+    It will be created in a subdirectory of `tempdir`, whose path will be
+    returned."""
+    locked = os.path.join(tempdir, 'svn' + '-' + 'locked')
+
+    # Create the locally locked repo:
+    repo = locked + '-repo'
+    repo_url = 'file:///' + repo.replace(os.sep, '/')
+    cc(['svnadmin', 'create', repo])
+    cc(['svn', 'co', repo_url, locked])
+
+    file_to_lock = os.path.join(locked, filename)
+
+    # Make the repo contain a locked file:
+    with open(file_to_lock, 'a') as f:
+        f.write(maxim)
+
+    cc(['svn', 'add', file_to_lock],
+       cwd=locked)
+    cc(['svn', 'commit', file_to_lock, '-m', 'add file to be locked'],
+       cwd=locked)
+    cc(['svn', 'lock', file_to_lock, '-m', 'lock file'], cwd=locked)
+
+    return locked
+
+
+def test_svn_lock_ignored(svn_locked):
+    """Do we omit locked files when `--ignore-svn-states` contains `K`?"""
+    actual_output = run('--ignore-svn-states', 'K', svn_locked)
+
+    # All dirty checkouts and only them:
+    expected_output = ""
+    assert actual_output == expected_output
+
+
+def test_svn_lock_detected(svn_locked):
+    """Do we detect svn repository having locked state?"""
+    actual_output = run(svn_locked)
+    expected_output = dedent("""\
+            {path} - Subversion
+                  K  {filename}
+
+            """).format(path=svn_locked, filename=filename)
+
+    assert actual_output == expected_output


### PR DESCRIPTION
* command.py (status-subversion): Skips repo if user supplied ignored
  states are found in status codes.
* command.py (main): Adds option for SVN ignored states.
* test_integration.py: SVN fixture for a locked repo (status code `K`).  Test
  for ignoring of locked repo if requested.  Test for discovery of locked repo
  in case no ignore option was given.