### PR TITLE
Added except block for FileNotFoundError.

### DIFF
--- a/uncommitted/command.py
+++ b/uncommitted/command.py
@@ -33,6 +33,11 @@ def run(command, **kw):
         return check_output(command, **kw).splitlines()
     except CalledProcessError:
         return ()
+    except FileNotFoundError:
+        print("The directory '{}' was skipped because the {} binary could "
+              "not be located.\n".format(kw['cwd'].decode("UTF-8"),
+                                         command[0]))
+        return ()
 
 def escape(s):
     """Escape the characters special to locate(1) globbing."""

--- a/uncommitted/command.py
+++ b/uncommitted/command.py
@@ -34,9 +34,8 @@ def run(command, **kw):
     except CalledProcessError:
         return ()
     except FileNotFoundError:
-        print("The directory '{}' was skipped because the {} binary could "
-              "not be located.\n".format(kw['cwd'].decode("UTF-8"),
-                                         command[0]))
+        print("The {} binary was not found. Skipping directory {}.\n"
+              .format(command[0], kw['cwd'].decode("UTF-8")))
         return ()
 
 def escape(s):


### PR DESCRIPTION
If a folder exists that indicates the presence of a repository (i.e
'.git', '.hg', and '.svn'), but the corresponding binary cannot be found
in the user's path, the application will now gracefully handle the error
by presenting the user with a message that the directory was skipped
because the corresponding binary could not be located.

As you can see from my testing below, the approach of catching the exception in the `run` method works quite well for Mercurial and Subversion, but the
message is printed 3-5 times for Git (depending on which command line
options were provided). One idea for a more robust solution would be to check for the
presence of the Git binary _before_ calling `run` in the `status_git`
function.

![image](https://user-images.githubusercontent.com/33665154/36407619-6554f086-15c5-11e8-845d-884db0931ee9.png)
