### PR TITLE
Fix parsing submodule paths

### DIFF
--- a/uncommitted/command.py
+++ b/uncommitted/command.py
@@ -17,7 +17,7 @@ class ErrorCannotLocate(Exception):
     """Signal that we cannot successfully run the locate(1) binary."""
 
 globchar = re.compile(br'([][*?])')
-git_submodule = re.compile(br'\s(\S*)\s\(.*\)')
+git_submodule = re.compile(br'^.\S+\s(.*)\s\(.*?\)$')
 linesep = os.linesep.encode('ascii')
 
 def output(thing):

--- a/uncommitted/test_integration.py
+++ b/uncommitted/test_integration.py
@@ -209,8 +209,8 @@ def repo_with_submodule(git_identity, tempdir, checkouts, cc):
     cc([system, 'init'], cwd=d)
 
     # Add a remote repo as a submodule:
-    submodule_name = system + '-clean'
-    remote = os.path.join(checkouts, submodule_name)
+    submodule_name = system + ' (submodule)'
+    remote = os.path.join(checkouts, system + '-clean')
     cc([system, 'submodule', 'add', '-f', remote, submodule_name], cwd=d)
     cc([system, 'commit', '-m', 'Initial commit with submodule.'], cwd=d)
 
@@ -446,7 +446,7 @@ def test_submodule(repo_with_submodule):
         {path} - Git
         [master]
 
-        {path}/git-clean - Git
+        {path}/git (submodule) - Git
         [non-tracking]
 
         """, path=repo_with_submodule)


### PR DESCRIPTION
Correctly handle submodule paths that end in the form ' (word)'.
Previously this would confuse the regex that parses `git submodule
status` (in a non-greedy fashion) and ended prematurely.

The fullmatch construct was introduced in Python 3.4, and is available
in all non-EOL Pythons:
https://devguide.python.org/devcycle/#end-of-life-branches

See https://github.com/sharkdp/bat for a test case.